### PR TITLE
testdata remove unsupported ssl directive

### DIFF
--- a/integration/testdata/ca_cert_apps/nginx_app/.nginx.conf.d/user-server.conf
+++ b/integration/testdata/ca_cert_apps/nginx_app/.nginx.conf.d/user-server.conf
@@ -1,4 +1,3 @@
- ssl on;
  ssl_certificate     "/workspace/certs/cert.pem";
  ssl_certificate_key "/workspace/certs/key.pem";
  index              index.php index.html;


### PR DESCRIPTION
"ssl" directive is removed in nginx 1.25.1, deprecated since 1.15.0


http://hg.nginx.org/nginx/rev/0aaa09927703
http://nginx.org/en/CHANGES
