### PR TITLE
stack upgrade test: pull lifecycle image

### DIFF
--- a/integration/stack_upgrade_test.go
+++ b/integration/stack_upgrade_test.go
@@ -39,9 +39,14 @@ func testStackUpgrades(t *testing.T, context spec.G, it spec.S) {
 		imageIDs = map[string]struct{}{}
 		containerIDs = map[string]struct{}{}
 
-		// pull the jammy builder images incase they haven't been pulled yet
+		// pull images associated with the jammy builder incase they haven't been pulled yet
 		Expect(docker.Pull.Execute("paketobuildpacks/builder-jammy-buildpackless-full")).To(Succeed())
 		Expect(docker.Pull.Execute("paketobuildpacks/run-jammy-full")).To(Succeed())
+		jammyBuilder, err := pack.Builder.Inspect.Execute("paketobuildpacks/builder-jammy-buildpackless-full")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(docker.Pull.Execute(
+			fmt.Sprintf("%s:%s", "buildpacksio/lifecycle", jammyBuilder.RemoteInfo.Lifecycle.Version),
+		)).To(Succeed())
 	})
 
 	it.After(func() {


### PR DESCRIPTION
The paketo bionic builder is now dead, and so its lifecycle image version is not in lockstep with jammy builder anymore.

Fixes error "failed to build: fetching lifecycle image: image 'buildpacksio/lifecycle:0.16.5' does not exist on the daemon"

(Note: you see this error if you flip the order of builders in integration.json. Currently the error is hidden because this test on bionic is run after tests on jammy)


## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
